### PR TITLE
Retry homebrew tap automation

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -36,8 +36,8 @@ jobs:
       url: ${{ steps.extract-details.outputs.url }}
       go_version: ${{ steps.extract-details.outputs.go_version }}
 
-  update-homebrew-tap:
-    name: Update Homebrew Tap
+  homebrew-tap:
+    name: Homebrew tap
     needs: release
     uses: anttiharju/homebrew-tap/.github/workflows/vmatch.yml@main
     with:


### PR DESCRIPTION
The referred job doesn't update with a 'retry failed jobs', hence the new pr.

Did some updates in the `homebrew-tap` repo that should help.