### PR TITLE
Support major.minor for language

### DIFF
--- a/pkg/finder/finder.go
+++ b/pkg/finder/finder.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 )
 
 type parser func(content []byte) (string, error)
 
-func GetVersion(filename string, parse parser) (string, error) {
+type validator func(version string) (string, error)
+
+func GetVersion(filename string, parse parser, validate validator) (string, error) {
 	location, err := locateFile(filename)
 	if err != nil {
 		return "", fmt.Errorf("cannot find version file '%s': %w", filename, err)
@@ -25,7 +26,7 @@ func GetVersion(filename string, parse parser) (string, error) {
 		return "", fmt.Errorf("could not parse %s: %w", location, err)
 	}
 
-	return validateVersion(version)
+	return validate(version)
 }
 
 func locateFile(filename string) (string, error) {
@@ -49,14 +50,4 @@ func locateFile(filename string) (string, error) {
 	}
 
 	return "", fmt.Errorf("cannot find version file '%s'", filename)
-}
-
-var versionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
-
-func validateVersion(version string) (string, error) {
-	if !versionPattern.MatchString(version) {
-		return "", fmt.Errorf("invalid version format '%s'", version)
-	}
-
-	return version, nil
 }

--- a/pkg/wrapper/language/language.go
+++ b/pkg/wrapper/language/language.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -31,10 +32,21 @@ func languageParser(content []byte) (string, error) {
 	return "", errors.New("cannot find go version")
 }
 
+// No patch as tools like stringer mandate not having it.
+var versionPattern = regexp.MustCompile(`^\d+\.\d+$`) // major.minor
+
+func validateVersion(version string) (string, error) {
+	if !versionPattern.MatchString(version) {
+		return "", fmt.Errorf("invalid version format '%s'", version)
+	}
+
+	return version, nil
+}
+
 func Wrap(name string) *WrappedLanguage {
 	baseWrapper := wrapper.BaseWrapper{Name: name}
 
-	desiredVersion, err := finder.GetVersion("go.mod", languageParser)
+	desiredVersion, err := finder.GetVersion("go.mod", languageParser, validateVersion)
 	if err != nil {
 		baseWrapper.ExitWithPrintln(exitcode.VersionReadFileIssue, err.Error())
 	}

--- a/pkg/wrapper/language/language.go
+++ b/pkg/wrapper/language/language.go
@@ -33,7 +33,7 @@ func languageParser(content []byte) (string, error) {
 }
 
 // No patch as tools like stringer mandate not having it.
-var versionPattern = regexp.MustCompile(`^\d+\.\d+$`) // major.minor
+var versionPattern = regexp.MustCompile(`^\d+\.\d+(?:\.\d+)?$`) // major.minor or major.minor.patch
 
 func validateVersion(version string) (string, error) {
 	if !versionPattern.MatchString(version) {

--- a/pkg/wrapper/linter/linter.go
+++ b/pkg/wrapper/linter/linter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -22,10 +23,20 @@ func linterParser(content []byte) (string, error) {
 	return trimmed, nil
 }
 
+var versionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`) // major.minor.patch
+
+func validateVersion(version string) (string, error) {
+	if !versionPattern.MatchString(version) {
+		return "", fmt.Errorf("invalid version format '%s'", version)
+	}
+
+	return version, nil
+}
+
 func Wrap(name string) *WrappedLinter {
 	baseWrapper := wrapper.BaseWrapper{Name: name}
 
-	desiredVersion, err := finder.GetVersion(".golangci-version", linterParser)
+	desiredVersion, err := finder.GetVersion(".golangci-version", linterParser, validateVersion)
 	if err != nil {
 		baseWrapper.ExitWithPrintln(exitcode.VersionReadFileIssue, err.Error())
 	}


### PR DESCRIPTION
Turns out some tools such as stringer mandate not locking patch version in go.mod so vmatch can not mandate otherwise