### PR TITLE
Add missing permissions

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -49,6 +49,8 @@ jobs:
     name: Distribute
     needs: release
     uses: ./.github/workflows/distribute.yml
+    permissions:
+      contents: write
     with:
       description: ${{ needs.release.outputs.description }}
       homepage: ${{ needs.release.outputs.homepage }}


### PR DESCRIPTION
```
[Invalid workflow file: .github/workflows/main_push.yml#L48](https://github.com/anttiharju/vmatch/actions/runs/13473458210/workflow)
The workflow is not valid. .github/workflows/main_push.yml (Line: 48, Col: 3): Error calling workflow 'anttiharju/vmatch/.github/workflows/distribute.yml@d2bd14676e832543fe61a52da5818e3b31186fcc'. The workflow is requesting 'contents: write', but is only allowed 'contents: read'.
```