### PR TITLE
Split Prettier into separate validation

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -1,4 +1,4 @@
-name: Main Push
+name: Project
 on:
   push:
     branches:

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -1,4 +1,3 @@
-name: Project
 on:
   push:
     branches:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: Project
 on: pull_request
 
 jobs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,3 @@
-name: Project
 on: pull_request
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,24 +11,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Style
-        uses: anttiharju/actions/lint-go@v0
-        with:
-          version-file: ".golangci-version"
-
-      - if: always()
-        name: Build
+      - name: Build
         uses: ./.github/actions/build
         with:
           cache: false # Suppress warning about a 'missing' go.sum
 
       - if: always()
-        name: Docs
-        uses: anttiharju/actions/lint-docs@v0
+        name: Style
+        uses: anttiharju/actions/lint-go@v0
+        with:
+          version-file: ".golangci-version"
 
       - if: always()
         name: Actions
         uses: anttiharju/actions/lint-actions@v0
+
+      - if: always()
+        name: Docs
+        uses: anttiharju/actions/lint-docs@v0
 
       - if: always()
         name: Prettier

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,8 +4,7 @@ on:
 
 # also update lefthook.yml
 jobs:
-  project:
-    name: Project
+  vmatch:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,3 +29,7 @@ jobs:
       - if: always()
         name: Actions
         uses: anttiharju/actions/lint-actions@v0
+
+      - if: always()
+        name: Prettier
+        uses: anttiharju/actions/prettier@v0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,18 +5,12 @@ output:
 # also update validate.yml
 pre-commit:
   jobs:
-    - name: Style
-      run: golangci-lint run --fix
-      glob: "{*.go,.golangci*}"
-      stage_fixed: true
-
     - name: Build
       run: go build
 
-    - name: Docs
-      run: |
-        mkdocs build --strict
-      glob: "{docs/**,mkdocs.yml}"
+    - name: Style
+      run: golangci-lint run --fix
+      glob: "{*.go,.golangci*}"
       stage_fixed: true
 
     - name: Actions
@@ -24,6 +18,12 @@ pre-commit:
         find ./.github -mindepth 2 -type f -name "*.yml" -exec action-validator --verbose {} +
         actionlint
       glob: ".github/**"
+      stage_fixed: true
+
+    - name: Docs
+      run: |
+        mkdocs build --strict
+      glob: "{docs/**,mkdocs.yml}"
       stage_fixed: true
 
     - name: Prettier

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,3 +25,9 @@ pre-commit:
         actionlint
       glob: ".github/**"
       stage_fixed: true
+
+    - name: Prettier
+      run: |
+        npx prettier --write .
+      glob: "{*.md,*.yml}"
+      stage_fixed: true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,7 +15,8 @@ pre-commit:
 
     - name: Actions
       run: |
-        find ./.github -mindepth 2 -type f -name "*.yml" -exec action-validator --verbose {} +
+        find ./.github -mindepth 2 -type f -name "*.yml" -exec \
+        action-validator --verbose {} +
         actionlint
       glob: ".github/**"
       stage_fixed: true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,7 +16,6 @@ pre-commit:
     - name: Docs
       run: |
         mkdocs build --strict
-        prettier --write "docs/**/*.md"
       glob: "{docs/**,mkdocs.yml}"
       stage_fixed: true
 
@@ -24,6 +23,5 @@ pre-commit:
       run: |
         find ./.github -mindepth 2 -type f -name "*.yml" -exec action-validator --verbose {} +
         actionlint
-        prettier --write ".github/**/*.{yml,yaml}"
       glob: ".github/**"
       stage_fixed: true


### PR DESCRIPTION
Do one thing and do it well

This way Prettier can prettify everything it can, and not just GitHub Actions -related YAMLs and Markdown files. This means `.golangci.yml` and `lefthook.yml` are now covered by Prettier.

Also changed functionality at https://github.com/anttiharju/actions