### PR TITLE
Fix validate job not triggering when there is no release

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
     paths: # This workflow is called by main.yml if these files have changed
+      - "**/*"
       - "!pkg/**/*"
       - "!scripts/**/*"
       - "!main.go"


### PR DESCRIPTION
I thought this was working based on

https://github.com/anttiharju/vmatch/commit/5e107618e4daf914029a3183aba958376bc6ace9

<img width="459" alt="image" src="https://github.com/user-attachments/assets/98af5381-8768-481d-9497-80f28aa65cc0" />

but it appears validate is not triggering on push to main per

- https://github.com/anttiharju/vmatch/commit/424f92ae1808fca6d90a6618b1ae610998f1e807
- https://github.com/anttiharju/vmatch/commit/bae005b0fe4433d92d96a0d033f1515c402a1b3b

<img width="451" alt="image" src="https://github.com/user-attachments/assets/c4003303-896c-49eb-abee-3ab85d0bf2f1" />
