### PR TITLE
Remove .vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["golang.go", "EditorConfig.EditorConfig"]
-}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -39,6 +39,6 @@ pre-commit:
       glob: "{docs/*,mkdocs.yml}"
 
     - name: Prettier
-      run: npx prettier --write .
+      run: npx --yes prettier --write .
       glob: "*{.md,.yml,.json}"
       stage_fixed: true


### PR DESCRIPTION
Benefit is minimal; distracts in tree structure; people should use whatever editor they like.

Also includes a Prettier lefthook fix, hook was left hanging.

Addresses:
* https://github.com/anttiharju/vmatch/issues/106