### PR TITLE
Make it possible to manually trigger releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - "scripts/**/*"
       - "main.go"
       - "go.mod"
+  workflow_dispatch:
 
 jobs:
   validate:


### PR DESCRIPTION
Sometimes CI fails on merge (generally try to avoid constructing CI in a way that allows that) so this is the escape hatch without making dummy changes.