### PR TITLE
Lefthook: catch cross-file refs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,11 +41,11 @@ jobs:
         uses: anttiharju/actions/editorconfig-checker@v0
 
       - if: always()
-        name: MkDocs build strict
-        uses: anttiharju/actions/mkdocs-build-strict@v0
-
-      - if: always()
         name: check-relative-links
         run: |
           # shellcheck disable=SC2046
           ./scripts/check-relative-links.bash $(git ls-files '*.md')
+
+      - if: always()
+        name: MkDocs build strict
+        uses: anttiharju/actions/mkdocs-build-strict@v0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,15 +17,15 @@ pre-commit:
 
     - name: action-validator
       glob: "{.github/workflows/*.yml,*/action.yml}"
-      run: action-validator --verbose {staged_files}
+      run: action-validator --verbose $(git ls-files '.github/workflows/*.yml' '*/action.yml')
 
     - name: actionlint
       glob: ".github/workflows/*.yml"
-      run: actionlint -color {staged_files}
+      run: actionlint -color
 
     - name: ShellCheck
       glob: "*{.sh,.bash}"
-      run: shellcheck --color=always --source-path=SCRIPTDIR --external-sources {staged_files}
+      run: shellcheck --color=always --source-path=SCRIPTDIR $(git ls-files '*.sh' '*.bash')
 
     - name: Prettier
       glob: "*{.md,.yml}"
@@ -33,13 +33,11 @@ pre-commit:
       stage_fixed: true
 
     - name: EditorConfig-Checker
-      glob: "*"
       run: editorconfig-checker {staged_files}
+
+    - name: check-relative-links
+      run: ./scripts/check-relative-links.bash $(git ls-files '*.md')
 
     - name: MkDocs build strict
       glob: "{mkdocs.yml,docs/*}"
       run: mkdocs build --strict
-
-    - name: check-relative-links
-      glob: "*"
-      run: ./scripts/check-relative-links.bash $(git ls-files '*.md')


### PR DESCRIPTION
{staged_files} only provides staged files, while {all_files} kills all granularity from the hooks, even if a glob has been defined

therefore by using the glob without {all_files} and using git ls-files to feed in all files of the same type (for example shellcheck can check whether sourced files exist) gets us correctness without sacrificing all granularity

maintaining some kind of index would be necessary for monorepos, perhaphs turborepo can do something like that. But that does not matter for this small project, more just for future ambitions.