### PR TITLE
Fix golangci-lint wrapping

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,7 +12,7 @@ pre-commit:
 
     - name: golangci-lint
       glob: "{*.go,.golangci*}"
-      run: golangci-lint run --fix {staged_files}
+      run: for file in '{staged_files}'; do golangci-lint run --fix "$file"; done
       stage_fixed: true
 
     - name: action-validator

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,7 +12,7 @@ pre-commit:
 
     - name: golangci-lint
       glob: "{*.go,.golangci*}"
-      run: for file in '{staged_files}'; do golangci-lint run --fix "$file"; done
+      run: golangci-lint run --fix
       stage_fixed: true
 
     - name: action-validator

--- a/main.go
+++ b/main.go
@@ -3,13 +3,13 @@ package main
 import (
 	"os"
 
+	"github.com/anttiharju/vmatch/pkg/choose"
 	"github.com/anttiharju/vmatch/pkg/interrupt"
-	"github.com/anttiharju/vmatch/pkg/picker"
 )
 
 func main() {
 	go interrupt.Listen(os.Interrupt)
 
-	exitCode := picker.SelectWrapper(os.Args[1:])
+	exitCode := choose.Wrapper(os.Args[1:])
 	os.Exit(exitCode)
 }

--- a/pkg/choose/choose.go
+++ b/pkg/choose/choose.go
@@ -19,7 +19,7 @@ func Wrapper(args []string) int {
 
 	if firstArgIs("golangci-lint", args) {
 		wrappedLinter := linter.Wrap("golangci-lint")
-		exitCode := wrappedLinter.Run(args)
+		exitCode := wrappedLinter.Run(args[1:])
 
 		return exitCode
 	}

--- a/pkg/choose/choose.go
+++ b/pkg/choose/choose.go
@@ -1,4 +1,4 @@
-package picker
+package choose
 
 import (
 	"github.com/anttiharju/vmatch/pkg/wrapper/language"
@@ -9,7 +9,7 @@ func firstArgIs(arg string, args []string) bool {
 	return len(args) > 0 && args[0] == arg
 }
 
-func SelectWrapper(args []string) int {
+func Wrapper(args []string) int {
 	if firstArgIs("go", args) {
 		wrappedLanguage := language.Wrap("go")
 		exitCode := wrappedLanguage.Run(args[1:])


### PR DESCRIPTION
First arg, i.e., golangci-lint, would not get stripped, leading to errors