### PR TITLE
Build bottles 6/n: add missing Go

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # required by render.bash
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
       - name: Create a local tap
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
forgot render.bash uses go