### PR TITLE
Connect wrapped binaries directly to the provided stdin, stdout, stderr

### DIFF
--- a/internal/inject/golangci-lint.sh
+++ b/internal/inject/golangci-lint.sh
@@ -1,7 +1,3 @@
 #!/usr/bin/env sh
 
-if [ -t 1 ]; then
-  colors=true
-fi
-
-VMATCH_GOLANGCI_LINT_COLORS=$colors vmatch golangci-lint "$@"
+vmatch golangci-lint "$@"

--- a/internal/inject/golangci-lint.sh
+++ b/internal/inject/golangci-lint.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env sh
 
-vmatch golangci-lint "$@"
+if [ -t 1 ]; then
+  colors=true
+fi
+
+TERMINAL=$colors /Users/antti/anttiharju/vmatch/vmatch golangci-lint "$@"

--- a/internal/inject/golangci-lint.sh
+++ b/internal/inject/golangci-lint.sh
@@ -4,4 +4,4 @@ if [ -t 1 ]; then
   colors=true
 fi
 
-TERMINAL=$colors /Users/antti/anttiharju/vmatch/vmatch golangci-lint "$@"
+VMATCH_GOLANGCI_LINT_COLORS=$colors vmatch golangci-lint "$@"

--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -71,8 +71,11 @@ func (w *WrappedLanguage) Run(ctx context.Context, args []string) int {
 	//nolint:gosec // I don't think a wrapper can avoid G204.
 	language := exec.Command(w.getGoPath(), args...)
 
-	languageOutput, _ := language.CombinedOutput()
-	fmt.Print(string(languageOutput))
+	language.Stdin = os.Stdin
+	language.Stdout = os.Stdout
+	language.Stderr = os.Stderr
+
+	_ = language.Run()
 
 	return language.ProcessState.ExitCode()
 }

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -57,7 +57,7 @@ func (w *WrappedLinter) Run(_ context.Context, args []string) int {
 		w.install()
 	}
 
-	if !slices.Contains(args, "--color") {
+	if os.Getenv("TERMINAL") == "true" && !slices.Contains(args, "--color") {
 		args = append(args, "--color", "always")
 	}
 

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -57,8 +57,12 @@ func (w *WrappedLinter) Run(_ context.Context, args []string) int {
 		w.install()
 	}
 
-	if os.Getenv("TERMINAL") == "true" && !slices.Contains(args, "--color") {
-		args = append(args, "--color", "always")
+	if !slices.Contains(args, "--color") {
+		if os.Getenv("VMATCH_GOLANGCI_LINT_COLORS") == "true" {
+			args = append(args, "--color", "always")
+		} else {
+			args = append(args, "--color", "never")
+		}
 	}
 
 	//nolint:gosec // I don't think a wrapper can avoid G204.

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -56,7 +56,7 @@ func (w *WrappedLinter) Run(_ context.Context, args []string) int {
 		w.install()
 	}
 
-	//nolint:gosec // I do not _think_ a wrapper can avoid this
+	//nolint:gosec // I don't think a wrapper can avoid G204.
 	linter := exec.Command(w.getGolangCILintPath(), args...)
 
 	linter.Stdin = os.Stdin

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"slices"
 	"strings"
 
 	"github.com/anttiharju/vmatch/internal/exitcode"
@@ -57,19 +56,14 @@ func (w *WrappedLinter) Run(_ context.Context, args []string) int {
 		w.install()
 	}
 
-	if !slices.Contains(args, "--color") {
-		if os.Getenv("VMATCH_GOLANGCI_LINT_COLORS") == "true" {
-			args = append(args, "--color", "always")
-		} else {
-			args = append(args, "--color", "never")
-		}
-	}
-
-	//nolint:gosec // I don't think a wrapper can avoid G204.
+	//nolint:gosec // I do not _think_ a wrapper can avoid this
 	linter := exec.Command(w.getGolangCILintPath(), args...)
 
-	linterOutput, _ := linter.CombinedOutput()
-	fmt.Print(string(linterOutput))
+	linter.Stdin = os.Stdin
+	linter.Stdout = os.Stdout
+	linter.Stderr = os.Stderr
+
+	_ = linter.Run()
 
 	return linter.ProcessState.ExitCode()
 }


### PR DESCRIPTION
This should fix `golangci-lint` VS Code integration. I _think_ it was broken because there was color output when there should not have been.