### PR TITLE
Remove pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,0 @@
-<!-- Use one of the following labels for your PR: -->
-<!-- major -->
-<!-- minor -->
-<!-- patch -->


### PR DESCRIPTION
CI will just simply fail. That was fixed alongside this PR in actions monorepo.