### PR TITLE
Prevent inconsistencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ jobs:
   github:
     name: GitHub
     runs-on: ubuntu-24.04
-    env:
-      # Disable CGO to ensure that the binaries are statically linked.
-      CGO_ENABLED: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/dist/github/release.bash
+++ b/dist/github/release.bash
@@ -12,7 +12,8 @@ echo "$os"
 echo "$arch"
 
 rm -rf "tmp/$os-$arch"
-go build -ldflags "-s -w -buildid=github-$version" -trimpath -o "tmp/$os-$arch/vmatch"
+# Disable CGO to ensure static linking
+CGO_ENABLED=0 go build -ldflags "-s -w -buildid=github-$version" -trimpath -o "tmp/$os-$arch/vmatch"
 
 cp LICENSE "tmp/$os-$arch"
 cp -r docs/* "tmp/$os-$arch"


### PR DESCRIPTION
Someone could run release.bash directly, so better to have the CGO disable there.