### PR TITLE
Define permissions at workflow-level for plan and release

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1,4 +1,7 @@
 name: Plan
+permissions:
+  contents: read
+  pull-requests: read
 on:
   pull_request:
     # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Release
+permissions:
+  contents: write
+  pull-requests: read
 on:
   workflow_call:
     inputs:
@@ -9,9 +12,6 @@ on:
       tag:
         description: "Whether to trigger release workflows"
         value: ${{ jobs.github.outputs.tag }}
-
-permissions:
-  contents: write
 
 jobs:
   github:


### PR DESCRIPTION
This might not work, but forcing a patch release to see the release pipeline succeed. In case it doesn't bumping job permissions for `pull-requests` to write as needed.