### PR TITLE
Fix golangci-lint wildcard

### DIFF
--- a/.github/workflows/wildcard-golangci-lint.yml
+++ b/.github/workflows/wildcard-golangci-lint.yml
@@ -9,6 +9,7 @@ on:
       - "**/*.go"
       - ".golangci-version"
       - ".golangci.yml"
+      - "go.mod"
 
 jobs:
   wildcard:


### PR DESCRIPTION
It let a merge workflow in master fail that should've been caught in pr ci: https://github.com/anttiharju/vmatch/actions/runs/18431479169

probably best to just always run everything haha