### PR TITLE
Downgrade Go because it's not packaged for Nix yet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/anttiharju/vmatch
 
-go 1.25.2
+go 1.25.1


### PR DESCRIPTION
I think this is one of the pain points with Nix people talk about

<img width="1240" height="362" alt="image" src="https://github.com/user-attachments/assets/afd2f401-cd56-4fbf-829e-78dbcd947af9" />
