### PR TITLE
Downgrade Go because it's not packaged for Nix yet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/anttiharju/vmatch
 
-go 1.25.1
+go 1.24.6


### PR DESCRIPTION
I use stable channel which is limited to 1.24.6, so ):)