### PR TITLE
Move fallback to right location to fix it

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -25,10 +25,11 @@ func Print() exitcode.Exitcode {
 				}
 			case "vcs.time":
 				buildTime = setting.Value
-				if buildTime == "" {
-					buildTime = "1970-01-01T00:00:00Z"
-				}
 			}
+		}
+
+		if buildTime == "" {
+			buildTime = "1970-01-01T00:00:00Z"
 		}
 
 		programName := filepath.Base(os.Args[0])


### PR DESCRIPTION
the key `vcs.time` probably doesn't even exist hence fallback never gets triggered