### PR TITLE
Try adding some ldflags

### DIFF
--- a/release/nix/template.nix
+++ b/release/nix/template.nix
@@ -11,5 +11,12 @@ buildGoModule {
     hash = "${PKG_HASH}";
   };
 
+  ldflags = [
+    "-s"
+    "-w"
+    "-buildid=nix-${PKG_VERSION}"
+    "-trimpath"
+  ];
+
   vendorHash = null;
 }


### PR DESCRIPTION
No idea if this will actually work, I imagine nix is already applying `-trimpath` and `-buildid=...` for reproducibility, but might as well try

Want to get something basic in first before starting to use `-X` to fix `version` subcommand output with Nix packaging