### PR TITLE
Remove extra v

### DIFF
--- a/release/nix/template.nix
+++ b/release/nix/template.nix
@@ -15,7 +15,7 @@ buildGoModule {
     "-s"
     "-w"
     "-X main.revision=${PKG_REV}"
-    "-X main.version=v${PKG_VERSION}"
+    "-X main.version=${PKG_VERSION}"
     "-X main.time=${PKG_TIME}"
   ];
 


### PR DESCRIPTION
Parity between brew and nix version subcommand outputs:

```sh
$ vmatch version
vmatch has version v1.0.34 built with go1.24.6 from 6b127876 on 2025-10-27T18:30:26Z
...
$ which vmatch
/opt/homebrew/bin/vmatch
$ vmatch version
vmatch has version 1.0.34 built with go1.24.6 from 6b127876 on 2025-10-27T18:30:26Z
```